### PR TITLE
add additional error cases

### DIFF
--- a/tcp_client.go
+++ b/tcp_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -278,10 +279,20 @@ func (c *TCPClient) Write(b []byte) (int, error) {
 			}
 			switch e := err.(type) {
 			case *net.OpError:
-				if e.Err.(syscall.Errno) == syscall.ECONNRESET ||
-					e.Err.(syscall.Errno) == syscall.EPIPE {
-					atomic.StoreInt32(&c.status, statusOffline)
-				} else {
+				switch e2 := e.Err.(type) {
+				case syscall.Errno:
+					if e2 == syscall.ECONNRESET || e2 == syscall.EPIPE {
+						atomic.StoreInt32(&c.status, statusOffline)
+					} else {
+						return n, err
+					}
+				case *os.SyscallError:
+					if e3, ok := e2.Err.(syscall.Errno); ok && e3 == syscall.ECONNRESET || e3 == syscall.EPIPE {
+						atomic.StoreInt32(&c.status, statusOffline)
+					} else {
+						return n, err
+					}
+				default:
 					return n, err
 				}
 			default:


### PR DESCRIPTION
golang's net package sometimes wraps the Syscall error in
os.SyscallError.  Added case to check for that and also, check ok
instead of panicking.